### PR TITLE
Migrate from `pykalman` to `pykalman-bardo`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy==1.20.2
 pandas==1.2.4
 altair==4.1.0
 scikit-learn==0.24.2
-pykalman-bardo==0.9.6
+pykalman-bardo==0.9.7
 notebook==6.4.7
 black>=21.11
 pmdarima==1.8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy==1.20.2
 pandas==1.2.4
 altair==4.1.0
 scikit-learn==0.24.2
-pykalman==0.9.5
+pykalman-bardo==0.9.6
 notebook==6.4.7
 black>=21.11
 pmdarima==1.8.4


### PR DESCRIPTION
Consider migration from `pykalman` to `pykalman-bardo`, as [pykalman](https://github.com/pykalman/pykalman) project is no longer maintained. There were some issues that were fixed, see: https://github.com/pybardo/pykalman/blob/v0.9.7/CHANGELOG

I'm going to maintain [pykalman-bardo](https://github.com/pybardo/pykalman), react to issues, and fix bugs. For now, the API is the same as in the initial package, but it might evolve in time.

I hope you will find it useful for your project!